### PR TITLE
nunjucks error handling

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,7 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 The beta release of Neanderthal.
 - [ ] Prerendered markdown syntax highlighting.
 - [ ] Markdown Nunjucks tag- towards the unified file format.
-- [ ] Error handling in Nunjucks templates.
+- [x] Error handling in Nunjucks templates.
 - [ ] Improvements to Frontmatter processing
   - [ ] Internal type safety
   - [ ] User-facing errors and warnings

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,12 @@
       "integrity": "sha512-rouEWBImiRaSJsVA+ITTFM6ZxibuAlTuNOCyxVbwreu6k6+ujs7DfnU9o+PShFhET78pMBl3eH+AGSI5eOTkPA==",
       "dev": true
     },
+    "@types/nunjucks": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/nunjucks/-/nunjucks-3.1.3.tgz",
+      "integrity": "sha512-42IiIIBdoB7ZDwCVhCWYT4fMCj+4TeacuVgh7xyT2du5EhkpA+OFeeDdYTFCUt1MrHb8Aw7ZqFvr8s1bwP9l8w==",
+      "dev": true
+    },
     "@types/serve-handler": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@types/serve-handler/-/serve-handler-6.1.0.tgz",
@@ -103,9 +109,9 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "binary-extensions": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
-      "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
+      "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
       "optional": true
     },
     "brace-expansion": {
@@ -137,9 +143,9 @@
       "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
     },
     "chokidar": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.0.tgz",
-      "integrity": "sha512-aXAaho2VJtisB/1fg1+3nlLJqGOuewTzQpd/Tz0yTg2R0e4IGtshYvtjowyEumcBv2z+y4+kc75Mz7j5xJskcQ==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.1.tgz",
+      "integrity": "sha512-TQTJyr2stihpC4Sya9hs2Xh+O2wf+igjL36Y75xx2WdHuiICcn/XJza46Jwt0eT5hVpQOzo3FpY3cj3RVYLX0g==",
       "optional": true,
       "requires": {
         "anymatch": "~3.1.1",
@@ -153,9 +159,9 @@
       }
     },
     "commander": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-      "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -404,14 +410,14 @@
       "optional": true
     },
     "nunjucks": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.1.tgz",
-      "integrity": "sha512-LYlVuC1ZNSalQQkLNNPvcgPt2M9FTY9bs39mTCuFXtqh7jWbYzhDlmz2M6onPiXEhdZo+b9anRhc+uBGuJZ2bQ==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.2.tgz",
+      "integrity": "sha512-KUi85OoF2NMygwODAy28Lh9qHmq5hO3rBlbkYoC8v377h4l8Pt5qFjILl0LWpMbOrZ18CzfVVUvIHUIrtED3sA==",
       "requires": {
         "a-sync-waterfall": "^1.0.0",
         "asap": "^2.0.3",
         "chokidar": "^3.3.0",
-        "commander": "^3.0.2"
+        "commander": "^5.1.0"
       }
     },
     "once": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "markdown-it": "^11.0.0",
     "markdown-it-footnote": "^3.0.2",
     "node-watch": "^0.6.4",
-    "nunjucks": "^3.2.1",
+    "nunjucks": "^3.2.2",
     "serve-handler": "^6.1.3",
     "source-map-support": "^0.5.19",
     "terminal-link": "^2.1.1",
@@ -39,6 +39,7 @@
     "@types/jasmine": "^3.5.11",
     "@types/markdown-it": "^10.0.1",
     "@types/node": "^14.0.13",
+    "@types/nunjucks": "^3.1.3",
     "@types/serve-handler": "^6.1.0",
     "jasmine": "^3.5.0",
     "typescript": "^3.9.5"

--- a/src/BlogPost.ts
+++ b/src/BlogPost.ts
@@ -5,7 +5,6 @@ import { writeFile, readFile, readFileIfExists } from "./helpers/io"
 import { copy } from "fs-extra"
 import { parse } from "path"
 const frontmatter = require("front-matter")
-const marked = require("marked")
 import markdownIt from "markdown-it"
 
 const md = markdownIt({
@@ -68,10 +67,8 @@ export default class BlogPost implements IResource {
     async write(path) {
         // Copy all dependencies
         // TODO: do this better using the new v0.2.0 structure
-        // console.log("COPY", parse(this.path).dir)
         await copy(parse(this.path).dir, parse(path).dir, {
             filter: (src: string, dest: string): boolean => {
-                // console.log(src, ",", this.path)
                 return src !== this.path
             }
         })

--- a/src/Builder.ts
+++ b/src/Builder.ts
@@ -52,7 +52,6 @@ export default class Builder {
                 })
                 post.write(buildPath)
             } else {
-                console.log("draft post")
             }
         })
     }
@@ -76,9 +75,14 @@ export default class Builder {
         let pageBuildDir = join(this.dirBuild, page.name)
         makeDir(pageBuildDir)
         let pageBuildFile = join(pageBuildDir, "index.html")
-        page.render({
-            meta: this.nconfig.meta
-        })
+        try {
+            page.render({
+                meta: this.nconfig.meta
+            })
+        } catch (err) {
+            this.cli.warn(err)
+        }
+
         await page.write(pageBuildFile)
         return pageBuildFile
     }
@@ -130,9 +134,13 @@ export default class Builder {
             let postPath = join("build", page.name)
             makeDir(postPath)
             let buildPath = join(postPath, "index.html")
-            page.render({
-                meta: this.nconfig.meta
-            })
+            try {
+                page.render({
+                    meta: this.nconfig.meta
+                })
+            } catch (err) {
+                this.cli.error(err)
+            }
             page.write(buildPath)
         })
 
@@ -218,7 +226,6 @@ export default class Builder {
                         } catch (err) {
                             this.cli.error(err)
                         }
-                        console.log(blogPost.attributes)
                         // Ignore draft posts
                         if (!blogPost.attributes.draft) {
                             return blogPost

--- a/src/CommandLine.ts
+++ b/src/CommandLine.ts
@@ -132,6 +132,10 @@ export default class CommandLine {
         }
     }
 
+    warn(err: NeanderthalError) {
+        console.log(`${c.bold.yellow("Warning")} Code: ${err.code}, ${err.message}`)
+    }
+
     error(err: NeanderthalError) {
         console.log(`${c.bold.red("Error")} Code: ${err.code}, ${err.message}`)
         process.exit(0)

--- a/src/CustomPage.ts
+++ b/src/CustomPage.ts
@@ -3,7 +3,8 @@ import { Template } from "./Template"
 import { writeFile, readFile, ioStats, readFileIfExists } from "./helpers/io"
 const frontmatter = require("front-matter")
 import * as fs from "fs-extra"
-const nunjucks = require("nunjucks")
+import { NunjucksRenderError, TempNunjucksRenderError } from "./helpers/exceptions"
+import * as nunjucks from "nunjucks"
 
 
 export default class CustomPage implements IResource {
@@ -34,9 +35,14 @@ export default class CustomPage implements IResource {
     }
 
     render(data): string {
-        let innerHTML = nunjucks.renderString(this.body, {
-            meta: data.meta || {}
-        })
+        let innerHTML = ""
+        try {
+            innerHTML = nunjucks.renderString(this.body, {
+                meta: data.meta || {}
+            })
+        } catch (err) {
+            throw new TempNunjucksRenderError(err.message)
+        }
 
         this.html = this.template.render({
             page: innerHTML,

--- a/src/helpers/exceptions.ts
+++ b/src/helpers/exceptions.ts
@@ -9,6 +9,27 @@ export class ResourceNotFound extends Error implements NeanderthalError {
     }
 }
 
+export class NunjucksRenderError extends Error implements NeanderthalError {
+    code: number
+    constructor(message, line, col) {
+        super(`Nunjucks error: ${message} [Line ${line}, Column ${col}]`)
+
+        this.name = this.constructor.name
+        this.code = -3
+    }
+}
+
+// https://github.com/mozilla/nunjucks/issues/1300
+export class TempNunjucksRenderError extends Error implements NeanderthalError {
+    code: number
+    constructor(message) {
+        super(`Nunjucks error: ${message}`)
+
+        this.name = this.constructor.name
+        this.code = -3
+    }
+}
+
 export interface NeanderthalError {
     name: string
     code: number


### PR DESCRIPTION
Add basic error handling for Nunjucks templates in Custom Pages.

There's an [issue](https://github.com/mozilla/nunjucks/issues/1300) in Nunjucks currently that causes us to need to use a limited form of error handling. Hopefully this is resolved soon.